### PR TITLE
Reverting to original goserial library

### DIFF
--- a/streaming/grbl.go
+++ b/streaming/grbl.go
@@ -2,7 +2,7 @@ package streaming
 
 import "io"
 import "bufio"
-import "github.com/joushou/goserial"
+import "github.com/tarm/goserial"
 import "github.com/joushou/gocnc/vm"
 import "github.com/joushou/gocnc/export"
 import "errors"


### PR DESCRIPTION
As Kenny pointed out in kennylevinsen/gocnc#12, the original library should work and it does work with MacOS and Raspberry Pi.